### PR TITLE
Adding openjson and org.json packages to 'string' tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,6 +16,16 @@
 			<version>0.2</version>
 		</dependency>
 		<dependency>
+			<groupId>com.github.openjson</groupId>
+			<artifactId>openjson</artifactId>
+			<version>1.0.0</version>
+		</dependency>
+		<dependency>
+			<groupId>org.json</groupId>
+			<artifactId>json</artifactId>
+			<version>20160810</version>
+		</dependency>
+		<dependency>
 			<groupId>com.google.code.gson</groupId>
 			<artifactId>gson</artifactId>
 			<version>2.6.1</version>

--- a/src/main/java/io/gatling/jsonbenchmark/string/OpenjsonBenchmark.java
+++ b/src/main/java/io/gatling/jsonbenchmark/string/OpenjsonBenchmark.java
@@ -1,0 +1,77 @@
+package io.gatling.jsonbenchmark.string;
+
+import com.github.openjson.JSONObject;
+import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.logic.BlackHole;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_ACTION_LABEL_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_CITM_CATALOG_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_MEDIUM_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_MENU_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_SGML_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_SMALL_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_WEBXML_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_WIDGET_BYTES;
+
+
+@State
+public class OpenjsonBenchmark {
+
+
+    private Object parse(String str) throws Exception {
+        return new JSONObject(str);
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit ( TimeUnit.SECONDS)
+    public void actionLabel(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_ACTION_LABEL_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void citmCatalog(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_CITM_CATALOG_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void medium(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_MEDIUM_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void menu(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_MENU_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void sgml(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_SGML_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void small(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_SMALL_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void webxml(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_WEBXML_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void widget(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_WIDGET_BYTES));
+    }
+}
+

--- a/src/main/java/io/gatling/jsonbenchmark/string/OrgJsonBenchmark.java
+++ b/src/main/java/io/gatling/jsonbenchmark/string/OrgJsonBenchmark.java
@@ -1,0 +1,77 @@
+package io.gatling.jsonbenchmark.string;
+
+import org.json.JSONObject;
+import org.openjdk.jmh.annotations.GenerateMicroBenchmark;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.logic.BlackHole;
+
+import java.util.concurrent.TimeUnit;
+
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_ACTION_LABEL_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_CITM_CATALOG_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_MEDIUM_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_MENU_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_SGML_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_SMALL_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_WEBXML_BYTES;
+import static io.gatling.jsonbenchmark.bytes.Buffers.STR_WIDGET_BYTES;
+
+
+@State
+public class OrgJsonBenchmark {
+
+
+    private Object parse(String str) throws Exception {
+        return new JSONObject(str);
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit ( TimeUnit.SECONDS)
+    public void actionLabel(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_ACTION_LABEL_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void citmCatalog(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_CITM_CATALOG_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void medium(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_MEDIUM_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void menu(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_MENU_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void sgml(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_SGML_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void small(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_SMALL_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void webxml(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_WEBXML_BYTES));
+    }
+
+    @GenerateMicroBenchmark
+    @OutputTimeUnit(TimeUnit.SECONDS)
+    public void widget(BlackHole bh) throws Exception {
+        bh.consume(parse(STR_WIDGET_BYTES));
+    }
+}
+


### PR DESCRIPTION
I added a popular org.json package that is used by number of developers and it's ApacheV2 clone: openjson.

I believe it could be really useful to see how major JSON libraries performs when compared to old classic ones.